### PR TITLE
add pattern to sheet name filter

### DIFF
--- a/src/lib/xlsx2seed.js
+++ b/src/lib/xlsx2seed.js
@@ -13,7 +13,7 @@ class Xlsx2Seed {
   get sheet_names() {
     return this._sheet_names
       || (this._sheet_names = this.book.SheetNames.filter(
-        (sheet_name) => sheet_name.match(/^[A-Za-z0-9_]+$/))
+        (sheet_name) => sheet_name.match(/^[A-Za-z0-9_.]+$/))
       );
   }
 


### PR DESCRIPTION
Sheet name filter does not support a name that contains dot.
Add a dot to match patterns.
